### PR TITLE
Workaround for bug when setting decimal number preferences

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<widget xmlns:tizen="http://tizen.org/ns/widgets" xmlns="http://www.w3.org/ns/widgets" id="https://discarded-ideas.org/OwntracksOSM" version="1.0.1" viewmodes="maximized">
+<widget xmlns:tizen="http://tizen.org/ns/widgets" xmlns="http://www.w3.org/ns/widgets" id="https://discarded-ideas.org/OwntracksOSM" version="1.0.2" viewmodes="maximized">
     <access origin="*" subdomains="true"></access>
     <access origin="https://opentopomap.org" subdomains="true"></access>
     <tizen:application id="kE6J4ZgyNX.OwntracksOSM" package="kE6J4ZgyNX" required_version="4.0"/>

--- a/js/main.js
+++ b/js/main.js
@@ -13,12 +13,12 @@ window.onload = function()
 	if (!tizen.preference.exists("gpsUpdateFrequency")) { tizen.preference.setValue("gpsUpdateFrequency", 10); }
 	if (!tizen.preference.exists("mqttPort")) { tizen.preference.setValue("mqttPort", 8883); }
 	if (!tizen.preference.exists("mqttDeviceID")) { tizen.preference.setValue("mqttDeviceID", "watch"); }
-	if (!tizen.preference.exists("mapLastLatitude")) { tizen.preference.setValue("mapLastLatitude", -35.30826); }
-	if (!tizen.preference.exists("mapLastLongitude")) { tizen.preference.setValue("mapLastLongitude", 149.12447); }
+	if (!tizen.preference.exists("mapLastLatitude")) { tizen.preference.setValue("mapLastLatitude", "-35.30826"); }
+	if (!tizen.preference.exists("mapLastLongitude")) { tizen.preference.setValue("mapLastLongitude", "149.12447"); }
 
 	// Set default until the first update
 	var map = new L.Map("map", {
-		center: new L.LatLng(tizen.preference.getValue("mapLastLatitude"), tizen.preference.getValue("mapLastLongitude")),
+		center: new L.LatLng(parseFloat(tizen.preference.getValue("mapLastLatitude")), parseFloat(tizen.preference.getValue("mapLastLongitude"))),
 		zoom: 14,
 		layers: [opentopo]
 	});
@@ -584,8 +584,8 @@ window.onload = function()
 				
 				// store last map position
 		    	var mapCenter = map.getCenter();
-		    	tizen.preference.setValue("mapLastLatitude",mapCenter.lat);
-		    	tizen.preference.setValue("mapLastLongitude",mapCenter.lng);
+		    	tizen.preference.setValue("mapLastLatitude",mapCenter.lat+"");
+		    	tizen.preference.setValue("mapLastLongitude",mapCenter.lng+"");
 		    	
     			tizen.application.getCurrentApplication().exit();
     		}


### PR DESCRIPTION
This pull request fixes #1 

For some reason, the app reports the following exception on my watch:
```
AbortError: Internal error
    at NativeManager.callSync (<anonymous>:1:22807)
    at PreferenceManager.setValue (<anonymous>:1:1457)
    at window.onload (file:///js/main.js:16:70)
```

This occurs when setting:
`tizen.preference.setValue("mapLastLatitude", -35.30826);`

I figured out that there seems to be a bug with setting preferences to decimal values, and I changed these preferences so that they are stored as strings.